### PR TITLE
do not explore if repo name is more than 8

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -278,6 +278,6 @@ function exit (err) {
 }
 
 function line (str, len) {
-    var line = new Array(len - str.length).join('-');
+    var line = new Array(Math.max(1, len - str.length)).join('-');
     return ' ' + line + ' ';
 }


### PR DESCRIPTION
if your repo name is more than 8 characters, this would fail.