### PR TITLE
fix test bug

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -181,12 +181,12 @@ function onTest(registry) {
     async.map(Object.keys(toTest), function(name, cbk) {
         var registry = toTest[name];
         var start = +new Date();
-        request(registry.registry + 'pedding', function(error) {
+        request(registry.registry + 'pedding', function(error, response) {
             cbk(null, {
                 name: name,
                 registry: registry.registry,
                 time: (+new Date() - start),
-                error: error ? true : false
+                error: error || response.statusCode !== 200 ? true : false
             });
         });
     }, function(err, results) {


### PR DESCRIPTION
Sometime, request get a bad http response without error. 
e.g. request("http://registry.mirror.cqupt.edu.cn") will get a status 502 but no error.

So,
If it don't get a 200 responseCode, it is also an error registry.
