### PR TITLE
Add yarn registry

### DIFF
--- a/registries.json
+++ b/registries.json
@@ -3,6 +3,10 @@
         "home": "https://www.npmjs.org",
         "registry": "https://registry.npmjs.org/"
     },
+    "yarn": {
+        "home": "https://yarnpkg.com",
+        "registry": "https://registry.yarnpkg.com"
+    },
     "cnpm": {
         "home": "http://cnpmjs.org",
         "registry": "http://r.cnpmjs.org/"


### PR DESCRIPTION
Add yarn registry so that we can rollback to default registry when use nrm with yarn. 