### PR TITLE
fix nrm current no reaction and humps camelize call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -238,9 +238,9 @@
       }
     },
     "npm": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npm.taobao.org/npm/download/npm-6.10.3.tgz",
-      "integrity": "sha1-gxlVmPiTCkDuSAVniDhjMhYmZm4=",
+      "version": "6.13.0",
+      "resolved": "https://registry.npm.taobao.org/npm/download/npm-6.13.0.tgz?cache=0&sync_timestamp=1572992710612&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnpm%2Fdownload%2Fnpm-6.13.0.tgz",
+      "integrity": "sha1-LpD6Wy91kBfZBqp1g/Dp7W6A4uI=",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -248,16 +248,16 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
+        "bin-links": "^1.1.3",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
-        "cacache": "^12.0.2",
+        "cacache": "^12.0.3",
         "call-limit": "^1.1.1",
-        "chownr": "^1.1.2",
+        "chownr": "^1.1.3",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
-        "cmd-shim": "~2.0.2",
+        "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
         "config-chain": "^1.1.12",
         "debuglog": "*",
@@ -269,11 +269,11 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
+        "gentle-fs": "^2.2.1",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
+        "graceful-fs": "^4.2.3",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.2",
+        "hosted-git-info": "^2.8.5",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
         "infer-owner": "^1.0.4",
@@ -284,7 +284,7 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.0",
+        "libcipm": "^4.0.7",
         "libnpm": "^3.0.1",
         "libnpmaccess": "^3.0.2",
         "libnpmhook": "^5.0.3",
@@ -310,33 +310,33 @@
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.0.3",
+        "node-gyp": "^5.0.5",
         "nopt": "~4.0.1",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^3.1.2",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.4.4",
-        "npm-pick-manifest": "^2.2.3",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.4",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.6",
+        "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.2",
-        "npm-registry-fetch": "^4.0.0",
+        "npm-registry-fetch": "^4.0.2",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.4",
+        "pacote": "^9.5.9",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
         "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
+        "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
+        "read-package-json": "^2.1.0",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.4.0",
         "readdir-scoped-modules": "^1.1.0",
@@ -344,14 +344,14 @@
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.7.0",
+        "semver": "^5.7.1",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.1",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.10",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -359,7 +359,7 @@
         "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
+        "uuid": "^3.3.3",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
@@ -507,13 +507,13 @@
           }
         },
         "bin-links": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.0.1",
+            "graceful-fs": "^4.1.15",
             "write-file-atomic": "^2.3.0"
           }
         },
@@ -559,7 +559,7 @@
           "bundled": true
         },
         "cacache": {
-          "version": "12.0.2",
+          "version": "12.0.3",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -605,7 +605,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true
         },
         "ci-info": {
@@ -667,7 +667,7 @@
           "bundled": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -1159,10 +1159,20 @@
           }
         },
         "fs-minipass": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "fs-vacuum": {
@@ -1252,13 +1262,15 @@
           "bundled": true
         },
         "gentle-fs": {
-          "version": "2.0.1",
+          "version": "2.2.1",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
             "mkdirp": "^0.5.1",
             "path-is-inside": "^1.0.2",
             "read-cmd-shim": "^1.0.1",
@@ -1336,7 +1348,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.0",
+          "version": "4.2.3",
           "bundled": true
         },
         "har-schema": {
@@ -1371,11 +1383,8 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.8.2",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^5.1.1"
-          }
+          "version": "2.8.5",
+          "bundled": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
@@ -1425,7 +1434,7 @@
           "bundled": true
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -1639,7 +1648,7 @@
           }
         },
         "libcipm": {
-          "version": "4.0.0",
+          "version": "4.0.7",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -1961,25 +1970,21 @@
           "version": "0.0.8",
           "bundled": true
         },
-        "minipass": {
-          "version": "2.3.3",
+        "minizlib": {
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
-              "bundled": true
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
             }
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -2041,7 +2046,7 @@
           }
         },
         "node-gyp": {
-          "version": "5.0.3",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "env-paths": "^1.0.0",
@@ -2053,7 +2058,7 @@
             "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^4.4.8",
+            "tar": "^4.4.12",
             "which": "1"
           },
           "dependencies": {
@@ -2114,14 +2119,14 @@
           "bundled": true
         },
         "npm-install-checks": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
-          "version": "3.1.2",
+          "version": "3.1.4",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
@@ -2139,17 +2144,17 @@
           "bundled": true
         },
         "npm-package-arg": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
+            "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
-            "semver": "^5.5.0",
+            "semver": "^5.6.0",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.4.4",
+          "version": "1.4.6",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2157,7 +2162,7 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.2.3",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -2175,7 +2180,7 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
@@ -2183,7 +2188,14 @@
             "figgy-pudding": "^3.4.1",
             "lru-cache": "^5.1.1",
             "make-fetch-happen": "^5.0.0",
-            "npm-package-arg": "^6.1.0"
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true
+            }
           }
         },
         "npm-run-path": {
@@ -2300,14 +2312,16 @@
           }
         },
         "pacote": {
-          "version": "9.5.4",
+          "version": "9.5.9",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
-            "cacache": "^12.0.0",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.1.0",
             "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^5.1.1",
             "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
@@ -2317,7 +2331,7 @@
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
             "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^2.2.3",
+            "npm-pick-manifest": "^3.0.0",
             "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
@@ -2327,13 +2341,13 @@
             "safe-buffer": "^5.1.2",
             "semver": "^5.6.0",
             "ssri": "^6.0.1",
-            "tar": "^4.4.8",
+            "tar": "^4.4.10",
             "unique-filename": "^1.1.1",
             "which": "^1.3.1"
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -2533,7 +2547,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.1",
+          "version": "1.0.5",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -2553,7 +2567,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.13",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
             "glob": "^7.1.1",
@@ -2677,7 +2691,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "semver-diff": {
@@ -2919,7 +2933,7 @@
           }
         },
         "stringify-package": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "strip-ansi": {
@@ -2945,12 +2959,12 @@
           }
         },
         "tar": {
-          "version": "4.4.10",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
+            "minipass": "^2.8.6",
             "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
@@ -2958,16 +2972,12 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true
             }
           }
         },
@@ -3124,7 +3134,7 @@
           }
         },
         "uuid": {
-          "version": "3.3.2",
+          "version": "3.3.3",
           "bundled": true
         },
         "validate-npm-package-license": {


### PR DESCRIPTION
1. `nrm current` and `nrm ls` not show current registry, because  non-custom registry never add `FIELD_IS_CURRENT` property, i don't find the purpose why that code appear
2. humps call camelize: there isn't a second parametor for ` { separator: '-' }`
3. when add a non-custom registry as a custom registry. just return and log the info
4. fix code style：add Semicolons at the end of the statements