### PR TITLE
fix(getiniinfo method): fix getINIInfo method

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -528,7 +528,7 @@ function getNPMInfo () {
 
 
 function getINIInfo (path) {
-    return fs.existsSync(path) ? ini.parse(fs.readFileSync(path, 'utf-8')) : {};
+    return fs.existsSync(path) ? JSON.parse(JSON.stringify(ini.parse(fs.readFileSync(path, 'utf-8')))) : {};
 }
 
 /*


### PR DESCRIPTION
ini repository v1.3.5 update decode method which  returns an object created by Object.create(null), so thorw an
error when calls hasOwnProperty method of the ruturn value from getINIInfo