### PR TITLE
修复nrm ls不显示星号问题,顺便修复nrm current不显示问题

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -208,10 +208,8 @@ function onUse (name) {
                 Object.keys(customRegistries).forEach(key => {
                     delete customRegistries[key][FIELD_IS_CURRENT];
                 });
-                if (hasOwnProperty(customRegistries, name) && (name in registries || customRegistries[name].registry === registry.registry)) {
-                    registry[FIELD_IS_CURRENT] = true;
-                    customRegistries[name] = registry;
-                }
+                registry[FIELD_IS_CURRENT] = true;
+                customRegistries[name] = registry;
                 setCustomRegistry(customRegistries);
                 printMsg(['', '   Registry has been set to: ' + newR, '']);
             }).catch(err => {


### PR DESCRIPTION
初次下载nrm使用nrm ls打印地址列表是不显示星号的，
使用nrm use taobao时，文件.nrmrc是空的，所以以下判断是不成立的
```js
if (hasOwnProperty(customRegistries, name) && (name in registries || customRegistries[name].registry === registry.registry)) {
                    registry[FIELD_IS_CURRENT] = true;
                    customRegistries[name] = registry;
}
```
所以我删除了判断条件，保留了以下内容
```js
  registry[FIELD_IS_CURRENT] = true;
  customRegistries[name] = registry;
```
直接写入文件即可，亲测显示正常