### PR TITLE
update taobao registry home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Usage: nrm [options] [command]
 * [yarn](https://yarnpkg.com)
 * [cnpm](http://cnpmjs.org)
 * [nodejitsu](https://www.nodejitsu.com)
-* [taobao](http://npm.taobao.org/)
+* [taobao](https://npmmirror.com)
 
 ## Related Projects
 

--- a/registries.json
+++ b/registries.json
@@ -16,7 +16,7 @@
         "registry": "https://r.cnpmjs.org/"
     },
     "taobao": {
-        "home": "https://npm.taobao.org",
+        "home": "https://npmmirror.com",
         "registry": "https://registry.npmmirror.com/"
     },
     "npmMirror": {


### PR DESCRIPTION
https://mp.weixin.qq.com/s/xNGu1xaXTGv3aWNP08QiYw

> 应该有不少开发者已经发现，访问淘宝 NPM 已经会自动 301 跳转到 npmmirror.com 新域名，这是我们独立注册和备案的域名。
> Web 站点：https://npmmirror.com
> Registry Endpoint：https://registry.npmmirror.com
> 随着新的域名已经正式启用，老 npm.taobao.org 和 registry.npm.taobao.org 域名将于 2022 年 05 月 31 日零时起停止服务。