### PR TITLE
npm auto publish

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,24 @@
+name: Npm Publish
+
+on:
+  pull_request:
+    branches:
+      - master
+  types: [closed]
+
+jobs:
+  publish:
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.github
+.editorconfig
+*.test.js


### PR DESCRIPTION
Auto Publish By GitHub Action .

To use the GitHub Action, the only thing you need to do is set the token parameter to your [NPM auth token](https://docs.npmjs.com/creating-and-viewing-access-tokens).