### PR TITLE
Fix ERR_REQUIRE_ESM

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-const open = require('open');
+const open = import('open');
 const chalk = require('chalk');
 const fetch = require('node-fetch');
 


### PR DESCRIPTION
```sh
$ nrm
C:\Users\sean\AppData\Roaming\npm\node_modules\nrm\cli.js:9
const open = require('open');
             ^

Error [ERR_REQUIRE_ESM]: require() of ES Module C:\Users\sean\AppData\Roaming\npm\node_modules\nrm\node_modules\open\index.js from C:\Users\sean\AppData\Roaming\npm\node_modules\nrm\cli.js not supported.
Instead change the require of index.js in C:\Users\sean\AppData\Roaming\npm\node_modules\nrm\cli.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (C:\Users\sean\AppData\Roaming\npm\node_modules\nrm\cli.js:9:14) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.12.0
```