### PR TITLE
fix: Change the tencent registry

### DIFF
--- a/.changeset/sweet-penguins-grin.md
+++ b/.changeset/sweet-penguins-grin.md
@@ -1,0 +1,5 @@
+---
+"nrm": patch
+---
+
+Updated tencent npm mirror registry

--- a/registries.json
+++ b/registries.json
@@ -8,8 +8,8 @@
     "registry": "https://registry.yarnpkg.com/"
   },
   "tencent": {
-    "home": "https://mirrors.cloud.tencent.com/npm/",
-    "registry": "https://mirrors.cloud.tencent.com/npm/"
+    "home": "https://mirrors.tencent.com/npm/",
+    "registry": "https://mirrors.tencent.com/npm/"
   },
   "cnpm": {
     "home": "https://cnpmjs.org",


### PR DESCRIPTION
The old Tencent registry(https://mirrors.cloud.tencent.com/npm/) is invaild
![image](https://github.com/user-attachments/assets/945a3eed-f8e2-4b83-9420-864a869415d5)


So need to change the new Tencent registry
see [the doc](https://www.tencentcloud.com/zh/document/product/213/8623?lang=zh#.E4.BD.BF.E7.94.A8.E8.85.BE.E8.AE.AF.E4.BA.91.E9.95.9C.E5.83.8F.E6.BA.90.E5.8A.A0.E9.80.9F-npm)

![image](https://github.com/user-attachments/assets/a308d326-8839-4b05-914e-24f29439501b)
