### PR TITLE
refactor: optimize onCurrent function

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -34,21 +34,23 @@ async function onList() {
 
 async function onCurrent({ showUrl }) {
   const currentRegistry = await getCurrentRegistry();
-  let usingUnknownRegistry = true;
   const registries = await getRegistries();
-  for (const name in registries) {
-    const registry = registries[name];
-    if (isLowerCaseEqual(registry[REGISTRY], currentRegistry)) {
-      usingUnknownRegistry = false;
-      printMessages([`You are using ${chalk.green(showUrl ? registry[REGISTRY] : name)} registry.`]);
-    }
-  }
-  if (usingUnknownRegistry) {
+
+  const matchedRegistry = Object.entries(registries).find(([_name, registry]) =>
+    isLowerCaseEqual(registry[REGISTRY], currentRegistry),
+  );
+
+  // not find equal registry
+  if (!matchedRegistry) {
     printMessages([
       `Your current registry(${currentRegistry}) is not included in the nrm registries.`,
       `Use the ${chalk.green('nrm add <registry> <url> [home]')} command to add your registry.`,
     ]);
+    return;
   }
+
+  const [name, registry] = matchedRegistry;
+  printMessages([`You are using ${chalk.green(showUrl ? registry[REGISTRY] : name)} registry.`]);
 }
 
 async function onUse(name) {


### PR DESCRIPTION
# Question

If it finds same registry, it still execute `if (usingUnknownRegistry) { }`. 

![image](https://github.com/user-attachments/assets/245aaa4e-be8c-470d-8eec-664a0ce98484)


It is not necessary. So I think I can optimize the logic.

# Improvement

I use `Object.entries()` and `find` to refactor it. It worked well. 



https://github.com/user-attachments/assets/9173c310-ad2a-4313-9214-e82be932f6af




## Compatibility

![image](https://github.com/user-attachments/assets/55e0330d-7aba-42fe-9830-eded4916bfe2)
