### PR TITLE
chore: add files field into package.json

### DIFF
--- a/.changeset/sixty-ants-occur.md
+++ b/.changeset/sixty-ants-occur.md
@@ -1,0 +1,5 @@
+---
+'nrm': patch
+---
+
+Optimize package files Thanks @chouchouji

--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     "type": "git",
     "url": "git://github.com/Pana/nrm.git"
   },
+  "files": [
+    "cli.js",
+    "actions.js",
+    "constants.js",
+    "helpers.js",
+    "process.js",
+    "registries.json"
+  ],
   "scripts": {
     "star": "npm star nrm",
     "test": "jest",


### PR DESCRIPTION
# Question

I download `nrm` package globally from npm. It includes some files that I don't need actually, such as `.github`, `tests`, `.changeset` and so no. 

So I think we should only keep some necessary files to this cli to work. It is very helpful for users to reduce package size and save disk.

![image](https://github.com/user-attachments/assets/5c482c99-bf0a-4749-b005-7f638b3b25dd)


# Link

[https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files)

![image](https://github.com/user-attachments/assets/734a5a6a-b1c7-4bfc-ac98-35d37d8e5461)
