### PR TITLE
chore: add specified registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com/


### PR DESCRIPTION
To avoid some things like this. 

![image](https://github.com/user-attachments/assets/91caa955-208b-4318-acf7-275a25abca6c)
