### PR TITLE
chore: optimize biome config and add dev script

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
+    "ignoreUnknown": true,
     "ignore": ["dist", "*.json"]
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "clean": "rimraf node_modules dist",
     "test": "pnpm build && vitest run",
+    "dev": "tsc --watch",
     "build": "rimraf dist && tsc && rimraf dist/types.js",
     "test:watch": "vitest",
     "changeset:version": "changeset version",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "vitest",
     "changeset:version": "changeset version",
     "changeset:publish": "changeset publish",
-    "check": "biome check --write ."
+    "check": "biome check --write --verbose"
   },
   "keywords": [
     "npm",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -15,8 +15,8 @@ import {
 } from 'vitest';
 
 import { onHome, onTest } from '../src/actions';
-import { readFile, writeFile } from '../src/helpers';
 import { NPMRC, REGISTRIES } from '../src/constants';
+import { readFile, writeFile } from '../src/helpers';
 
 const isWin = process.platform === 'win32';
 
@@ -98,7 +98,11 @@ it('nrm use <registry> local', async () => {
 
   expect(npmrc.registry).toBe(REGISTRIES.cnpm.registry);
 
-  await coffee.spawn('nrm', ['current'], { shell: isWin }).expect('stdout', /cnpm/g).expect('code', 0).end();
+  await coffee
+    .spawn('nrm', ['current'], { shell: isWin })
+    .expect('stdout', /cnpm/g)
+    .expect('code', 0)
+    .end();
 });
 
 it('nrm use <registry> local with user config', async () => {
@@ -115,7 +119,11 @@ it('nrm use <registry> local with user config', async () => {
   expect(npmrc.registry).toBe(REGISTRIES.cnpm.registry);
   expect(npmrc.abc).toBe('123');
 
-  await coffee.spawn('nrm', ['current'], { shell: isWin }).expect('stdout', /cnpm/g).expect('code', 0).end();
+  await coffee
+    .spawn('nrm', ['current'], { shell: isWin })
+    .expect('stdout', /cnpm/g)
+    .expect('code', 0)
+    .end();
 });
 
 it('nrm use without argument', async () => {
@@ -127,7 +135,9 @@ it('nrm use without argument', async () => {
     });
   });
 
-  expect(message).toBe(`? Please select the registry you want to use (Use arrow keys)
+  expect(
+    message,
+  ).toBe(`? Please select the registry you want to use (Use arrow keys)
 ${isWin ? '>' : '❯'} npm
   yarn
   tencent


### PR DESCRIPTION
# Result 

I think `--verbose` is helpful to check which files are lint.

![image](https://github.com/user-attachments/assets/3aba100e-5341-4797-9e07-ff496c5d9c73)

# Docs

[https://biomejs.dev/reference/diagnostics/#verbose](https://biomejs.dev/reference/diagnostics/#verbose)
